### PR TITLE
Elipsis into model template

### DIFF
--- a/openapi-python-templates/model.mustache
+++ b/openapi-python-templates/model.mustache
@@ -31,7 +31,7 @@ class {{classname}}(BaseModel):
     {{name}}: "{{^required}}Optional[{{/required}}{{>_dataTypeModel}}{{^required}}]{{/required}}" = Field({{#required}}...{{/required}}{{^required}}None{{/required}}, alias="{{baseName}}")
 {{/isEnum}}
 {{/vars}}
-...
+    ...
 {{/allowableValues}}
 
 {{/model}}

--- a/openapi-python-templates/model.mustache
+++ b/openapi-python-templates/model.mustache
@@ -31,6 +31,7 @@ class {{classname}}(BaseModel):
     {{name}}: "{{^required}}Optional[{{/required}}{{>_dataTypeModel}}{{^required}}]{{/required}}" = Field({{#required}}...{{/required}}{{^required}}None{{/required}}, alias="{{baseName}}")
 {{/isEnum}}
 {{/vars}}
+...
 {{/allowableValues}}
 
 {{/model}}


### PR DESCRIPTION
Java Micronaut seems to export even classes without properties into open API spec. Those models then get rendered without a body, which is syntactically incorrect. Adding an ellipsis to the end of the body does not affect classes with properties, but fixes the validity of classes without properties.