### PR TITLE
Allow use of swagger v2 basePath

### DIFF
--- a/openapi-python-templates/__init__package.mustache
+++ b/openapi-python-templates/__init__package.mustache
@@ -6,7 +6,6 @@ from @IMPORT_NAME@.api_client import ApiClient, AsyncApis, SyncApis  # noqa F401
 
 
 for model in inspect.getmembers(models, inspect.isclass):
-	if model[1].__module__ == "@IMPORT_NAME@.models":
-		model_class = model[1]
-		if isinstance(model_class, BaseModel):
-			model_class.update_forward_refs()
+  model_class = model[1]
+  if issubclass(model_class, BaseModel):
+    model_class.update_forward_refs()

--- a/openapi-python-templates/api.mustache
+++ b/openapi-python-templates/api.mustache
@@ -112,7 +112,7 @@ class _{{classname}}:
         return self.api_client.request(
             type_={{>_returnType}},
             method="{{httpMethod}}",
-            url="{{{path}}}",
+            url="{{{basePathWithoutHost}}}{{{path}}}",
             {{#pathParams.0}}path_params=path_params,{{/pathParams.0}}
             {{#queryParams.0}}params=query_params,{{/queryParams.0}}
             {{#headerParams.0}}headers=headers,{{/headerParams.0}}


### PR DESCRIPTION
When generating urls, use the swagger v2 basePath if one is defined.

This generated full URLs correctly using either a v2 swagger API with
a basePath declaration or an OpenAPI v3 schema that never has this
value.

Also fix forward refs correctly (https://github.com/dmontagu/fastapi_client/issues/27) so we don't need to replace this file later in the generation pipeline.
